### PR TITLE
Updates to build and run seamlessly

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,5 @@
 platform :ios, '6.0'
+source 'https://github.com/CocoaPods/Specs.git'
 
 target 'VENCore', :exclusive => true do
   pod 'CMDQueryStringSerialization', '~> 0.2.0'

--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,7 @@
-platform :ios, '6.0'
 source 'https://github.com/CocoaPods/Specs.git'
+
+platform :ios, '6.0'
+inhibit_all_warnings!
 
 target 'VENCore', :exclusive => true do
   pod 'CMDQueryStringSerialization', '~> 0.2.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - CMDQueryStringSerialization (0.2.0)
   - Expecta (0.3.0)
-  - Nocilla (0.8.1)
+  - Nocilla (0.9.0)
   - OCHamcrest (3.0.1)
   - OCMock (2.2.4)
   - Specta (0.2.1)
@@ -17,9 +17,9 @@ DEPENDENCIES:
 SPEC CHECKSUMS:
   CMDQueryStringSerialization: e53570ccbce6004acba30b1c1210e254644cdb92
   Expecta: ce8a51b9fad15a2cd573b291cb2909aaed865350
-  Nocilla: e573c2bf9113c8d77782b695a2f9362b7bc44e72
+  Nocilla: 4d713c56e7357fd0cac0363854d4a58021ad3f41
   OCHamcrest: 207233b7d7a44dadd66aca398947cc7e029c9be5
   OCMock: 6db79185520e24f9f299548f2b8b07e41d881bd5
   Specta: 9141310f46b1f68b676650ff2854e1ed0b74163a
 
-COCOAPODS: 0.33.1
+COCOAPODS: 0.34.4

--- a/VENCore.xcodeproj/project.pbxproj
+++ b/VENCore.xcodeproj/project.pbxproj
@@ -15,9 +15,9 @@
 		4796D62318FC4B6D001461B1 /* VENUserSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 4796D61F18FC4B6D001461B1 /* VENUserSpec.m */; };
 		47BD36E018FDBA4500DE4554 /* fetchChrisUser.json in Resources */ = {isa = PBXBuildFile; fileRef = 47BD36DF18FDBA4500DE4554 /* fetchChrisUser.json */; };
 		9B2C2CF9196C992000D1B241 /* fetchInvalidFriends.json in Resources */ = {isa = PBXBuildFile; fileRef = 9B2C2CF8196C992000D1B241 /* fetchInvalidFriends.json */; };
-		9BF60703196C333000F163E5 /* fetchFriends.json in Resources */ = {isa = PBXBuildFile; fileRef = 9BF60702196C333000F163E5 /* fetchFriends.json */; };
 		9B2C2D06196ED75400D1B241 /* NSArray+VENCore.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B2C2D05196ED75400D1B241 /* NSArray+VENCore.m */; };
 		9B2C2D09196EDC3000D1B241 /* NSArray+VENCoreSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B2C2D08196EDC3000D1B241 /* NSArray+VENCoreSpec.m */; };
+		9BF60703196C333000F163E5 /* fetchFriends.json in Resources */ = {isa = PBXBuildFile; fileRef = 9BF60702196C333000F163E5 /* fetchFriends.json */; };
 		C24E595918F84C67009670F7 /* VENTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = C24E595418F84C67009670F7 /* VENTransaction.m */; };
 		C24E595A18F84C67009670F7 /* VENUser.m in Sources */ = {isa = PBXBuildFile; fileRef = C24E595718F84C67009670F7 /* VENUser.m */; };
 		E84803CCC64F49DB9C88AD75 /* libPods-VENCoreIntegrationTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 25B6CD691E644507A1045E0D /* libPods-VENCoreIntegrationTests.a */; };
@@ -93,31 +93,34 @@
 
 /* Begin PBXFileReference section */
 		1DC461A27E94407698BE1D38 /* libPods-VENCore.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VENCore.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2299F0B62490768BB5F57AD5 /* Pods-VENCore.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VENCore.debug.xcconfig"; path = "Pods/Target Support Files/Pods-VENCore/Pods-VENCore.debug.xcconfig"; sourceTree = "<group>"; };
 		25B6CD691E644507A1045E0D /* libPods-VENCoreIntegrationTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VENCoreIntegrationTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AE56FEE190871DF0054B7EF /* VENCreateTransactionRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VENCreateTransactionRequest.h; sourceTree = "<group>"; };
 		3AE56FEF190871DF0054B7EF /* VENCreateTransactionRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VENCreateTransactionRequest.m; sourceTree = "<group>"; };
 		3AE56FF11908A0610054B7EF /* VENCreateTransactionRequestSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VENCreateTransactionRequestSpec.m; sourceTree = "<group>"; };
+		408B73436672161A6E658C0A /* Pods-VENCoreIntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VENCoreIntegrationTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-VENCoreIntegrationTests/Pods-VENCoreIntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		47136D3A18FF001F00AD63CD /* VENTransactionPayloadKeys.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VENTransactionPayloadKeys.h; sourceTree = "<group>"; };
 		4779F161125042D590B452A8 /* libPods-VENCoreUnitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VENCoreUnitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4796A38618FDD4C6005CABA6 /* fetchInvalidUser.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = fetchInvalidUser.json; sourceTree = "<group>"; };
 		4796D61C18FC4B6D001461B1 /* VENTransactionSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VENTransactionSpec.m; sourceTree = "<group>"; };
 		4796D61F18FC4B6D001461B1 /* VENUserSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VENUserSpec.m; sourceTree = "<group>"; };
 		47BD36DF18FDBA4500DE4554 /* fetchChrisUser.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = fetchChrisUser.json; sourceTree = "<group>"; };
+		8DC83783EE040709FC6010F2 /* Pods-VENCoreUnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VENCoreUnitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-VENCoreUnitTests/Pods-VENCoreUnitTests.release.xcconfig"; sourceTree = "<group>"; };
+		9AC1B33379403B14507B5B3C /* Pods-VENCoreUnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VENCoreUnitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-VENCoreUnitTests/Pods-VENCoreUnitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9B2C2CF8196C992000D1B241 /* fetchInvalidFriends.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = fetchInvalidFriends.json; sourceTree = "<group>"; };
-		9BF60702196C333000F163E5 /* fetchFriends.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = fetchFriends.json; sourceTree = "<group>"; };
 		9B2C2D04196ED75400D1B241 /* NSArray+VENCore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSArray+VENCore.h"; path = "Categories/NSArray+VENCore.h"; sourceTree = "<group>"; };
 		9B2C2D05196ED75400D1B241 /* NSArray+VENCore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSArray+VENCore.m"; path = "Categories/NSArray+VENCore.m"; sourceTree = "<group>"; };
 		9B2C2D08196EDC3000D1B241 /* NSArray+VENCoreSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSArray+VENCoreSpec.m"; path = "Categories/NSArray+VENCoreSpec.m"; sourceTree = "<group>"; };
-		A1AE1BF8A82F4124AD872FD8 /* Pods-VENCore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VENCore.xcconfig"; path = "Pods/Pods-VENCore.xcconfig"; sourceTree = "<group>"; };
-		B5284720DE944039BF66DD7A /* Pods-VENCoreUnitTests.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VENCoreUnitTests.xcconfig"; path = "Pods/Pods-VENCoreUnitTests.xcconfig"; sourceTree = "<group>"; };
+		9BF60702196C333000F163E5 /* fetchFriends.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = fetchFriends.json; sourceTree = "<group>"; };
 		BB802D1BBF75489EBAC57A1E /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		BD39034CA1D2B6C529E03B17 /* Pods-VENCore.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VENCore.release.xcconfig"; path = "Pods/Target Support Files/Pods-VENCore/Pods-VENCore.release.xcconfig"; sourceTree = "<group>"; };
+		BDF75E93007ED946B3C7BB8D /* Pods-VENCoreIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VENCoreIntegrationTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-VENCoreIntegrationTests/Pods-VENCoreIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		C24E595318F84C67009670F7 /* VENTransaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VENTransaction.h; sourceTree = "<group>"; };
 		C24E595418F84C67009670F7 /* VENTransaction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VENTransaction.m; sourceTree = "<group>"; };
 		C24E595618F84C67009670F7 /* VENUser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VENUser.h; sourceTree = "<group>"; };
 		C24E595718F84C67009670F7 /* VENUser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VENUser.m; sourceTree = "<group>"; };
 		C24E595E18F87FF2009670F7 /* VENMutableUserSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VENMutableUserSpec.m; sourceTree = "<group>"; };
 		C24E596018F885D7009670F7 /* VENUserPayloadKeys.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VENUserPayloadKeys.h; sourceTree = "<group>"; };
-		DB8119F699444A64A89AF20C /* Pods-VENCoreIntegrationTests.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VENCoreIntegrationTests.xcconfig"; path = "Pods/Pods-VENCoreIntegrationTests.xcconfig"; sourceTree = "<group>"; };
 		EB00DB341906E647001836A8 /* VENCoreIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VENCoreIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB00DB3A1906E647001836A8 /* VENCoreIntegrationTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "VENCoreIntegrationTests-Info.plist"; sourceTree = "<group>"; };
 		EB00DB3C1906E647001836A8 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -207,6 +210,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		237A43440551AF655B8BC3CF /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				2299F0B62490768BB5F57AD5 /* Pods-VENCore.debug.xcconfig */,
+				BD39034CA1D2B6C529E03B17 /* Pods-VENCore.release.xcconfig */,
+				408B73436672161A6E658C0A /* Pods-VENCoreIntegrationTests.debug.xcconfig */,
+				BDF75E93007ED946B3C7BB8D /* Pods-VENCoreIntegrationTests.release.xcconfig */,
+				9AC1B33379403B14507B5B3C /* Pods-VENCoreUnitTests.debug.xcconfig */,
+				8DC83783EE040709FC6010F2 /* Pods-VENCoreUnitTests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 		4796D61118FC4B3E001461B1 /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -374,7 +390,6 @@
 		EBBE7E1118EA089200E47338 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				EB58F97C18F75B25008A6914 /* VENMutableTransactionSpec.m */,
 				EB9BF00718EA83B500416645 /* VENUserSpec.m */,
 				C24E595E18F87FF2009670F7 /* VENMutableUserSpec.m */,
 				EB418B9618EB0DA30003CBF5 /* VENTransactionSpec.m */,
@@ -391,9 +406,7 @@
 				EB00DB381906E647001836A8 /* VENCoreIntegrationTests */,
 				EBCB247618E9FBAF00807472 /* Frameworks */,
 				EBCB247518E9FBAF00807472 /* Products */,
-				A1AE1BF8A82F4124AD872FD8 /* Pods-VENCore.xcconfig */,
-				DB8119F699444A64A89AF20C /* Pods-VENCoreIntegrationTests.xcconfig */,
-				B5284720DE944039BF66DD7A /* Pods-VENCoreUnitTests.xcconfig */,
+				237A43440551AF655B8BC3CF /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -619,7 +632,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-VENCoreUnitTests-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-VENCoreUnitTests/Pods-VENCoreUnitTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		A75C89F4BED9494FA5602BF2 /* Copy Pods Resources */ = {
@@ -634,7 +647,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-VENCoreIntegrationTests-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-VENCoreIntegrationTests/Pods-VENCoreIntegrationTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		B967137252804E7C989C6BF5 /* Check Pods Manifest.lock */ = {
@@ -679,7 +692,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-VENCore-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-VENCore/Pods-VENCore-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F8C3EB7371DA45E59C26154F /* Check Pods Manifest.lock */ = {
@@ -786,7 +799,7 @@
 /* Begin XCBuildConfiguration section */
 		EB00DB431906E647001836A8 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DB8119F699444A64A89AF20C /* Pods-VENCoreIntegrationTests.xcconfig */;
+			baseConfigurationReference = 408B73436672161A6E658C0A /* Pods-VENCoreIntegrationTests.debug.xcconfig */;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -800,6 +813,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "VENCoreIntegrationTests/VENCoreIntegrationTests-Info.plist";
+				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = xctest;
 			};
@@ -807,7 +821,7 @@
 		};
 		EB00DB441906E647001836A8 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DB8119F699444A64A89AF20C /* Pods-VENCoreIntegrationTests.xcconfig */;
+			baseConfigurationReference = BDF75E93007ED946B3C7BB8D /* Pods-VENCoreIntegrationTests.release.xcconfig */;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -817,6 +831,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "VENCoreIntegrationTests/VENCoreIntegrationTests-Prefix.pch";
 				INFOPLIST_FILE = "VENCoreIntegrationTests/VENCoreIntegrationTests-Info.plist";
+				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = xctest;
 			};
@@ -904,7 +919,7 @@
 		};
 		EBCB249818E9FBAF00807472 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A1AE1BF8A82F4124AD872FD8 /* Pods-VENCore.xcconfig */;
+			baseConfigurationReference = 2299F0B62490768BB5F57AD5 /* Pods-VENCore.debug.xcconfig */;
 			buildSettings = {
 				DSTROOT = /tmp/VENCore.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -920,7 +935,7 @@
 		};
 		EBCB249918E9FBAF00807472 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A1AE1BF8A82F4124AD872FD8 /* Pods-VENCore.xcconfig */;
+			baseConfigurationReference = BD39034CA1D2B6C529E03B17 /* Pods-VENCore.release.xcconfig */;
 			buildSettings = {
 				DSTROOT = /tmp/VENCore.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -936,7 +951,7 @@
 		};
 		EBCB249B18E9FBAF00807472 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B5284720DE944039BF66DD7A /* Pods-VENCoreUnitTests.xcconfig */;
+			baseConfigurationReference = 9AC1B33379403B14507B5B3C /* Pods-VENCoreUnitTests.debug.xcconfig */;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -957,7 +972,7 @@
 		};
 		EBCB249C18E9FBAF00807472 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B5284720DE944039BF66DD7A /* Pods-VENCoreUnitTests.xcconfig */;
+			baseConfigurationReference = 8DC83783EE040709FC6010F2 /* Pods-VENCoreUnitTests.release.xcconfig */;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",

--- a/VENCore.xcodeproj/xcshareddata/xcschemes/VENCore.xcscheme
+++ b/VENCore.xcodeproj/xcshareddata/xcschemes/VENCore.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:VENCore.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EBCB248318E9FBAF00807472"
+               BuildableName = "VENCoreUnitTests.xctest"
+               BlueprintName = "VENCoreUnitTests"
+               ReferencedContainer = "container:VENCore.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -49,6 +63,15 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EBCB247318E9FBAF00807472"
+            BuildableName = "libVENCore.a"
+            BlueprintName = "VENCore"
+            ReferencedContainer = "container:VENCore.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -59,6 +82,15 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EBCB247318E9FBAF00807472"
+            BuildableName = "libVENCore.a"
+            BlueprintName = "VENCore"
+            ReferencedContainer = "container:VENCore.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -68,6 +100,15 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EBCB247318E9FBAF00807472"
+            BuildableName = "libVENCore.a"
+            BlueprintName = "VENCore"
+            ReferencedContainer = "container:VENCore.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/VENCoreIntegrationTests/PaymentSandboxSpec.m
+++ b/VENCoreIntegrationTests/PaymentSandboxSpec.m
@@ -33,7 +33,7 @@ describe(@"Settled Payment", ^{
             expect(sentTransaction.status).to.equal(VENTransactionStatusSettled);
             done();
         } failure:^(NSArray *sentTransactions, VENHTTPResponse *response, NSError *error) {
-            XCTFail();
+            VENFail();
             done();
         }];
     });
@@ -50,7 +50,7 @@ describe(@"Settled Payment", ^{
             expect(sentTransaction.status).to.equal(VENTransactionStatusSettled);           
             done();
         } failure:^(NSArray *sentTransactions, VENHTTPResponse *response, NSError *error) {
-            XCTFail();
+            VENFail();
             done();
         }];
     });
@@ -68,7 +68,7 @@ describe(@"Settled Payment", ^{
             expect(sentTransaction.status).to.equal(VENTransactionStatusSettled);
             done();
         } failure:^(NSArray *sentTransactions, VENHTTPResponse *response, NSError *error) {
-            XCTFail();
+            VENFail();
             done();
         }];
     });
@@ -96,7 +96,7 @@ describe(@"Failed Payment", ^{
             expect(sentTransaction.status).to.equal(VENTransactionStatusFailed);
             done();
         } failure:^(NSArray *sentTransactions, VENHTTPResponse *response, NSError *error) {
-            XCTFail();
+            VENFail();
             done();
         }];
     });
@@ -124,7 +124,7 @@ describe(@"Pending Payment", ^{
             expect(sentTransaction.status).to.equal(VENTransactionStatusPending);
             done();
         } failure:^(NSArray *sentTransactions, VENHTTPResponse *response, NSError *error) {
-            XCTFail();
+            VENFail();
             done();
         }];
 
@@ -142,7 +142,7 @@ describe(@"Pending Payment", ^{
             expect(sentTransaction.status).to.equal(VENTransactionStatusPending);
             done();
         } failure:^(NSArray *sentTransactions, VENHTTPResponse *response, NSError *error) {
-            XCTFail();
+            VENFail();
             done();
         }];       
     });
@@ -171,7 +171,7 @@ describe(@"Settled Charge", ^{
             expect(sentTransaction.status).to.equal(VENTransactionStatusSettled);
             done();
         } failure:^(NSArray *sentTransactions, VENHTTPResponse *response, NSError *error) {
-            XCTFail();
+            VENFail();
             done();
         }];
     });
@@ -200,7 +200,7 @@ describe(@"Pending Charge", ^{
             expect(sentTransaction.status).to.equal(VENTransactionStatusPending);
             done();
         } failure:^(NSArray *sentTransactions, VENHTTPResponse *response, NSError *error) {
-            XCTFail();
+            VENFail();
             done();
         }];       
     });

--- a/VENCoreIntegrationTests/VENCoreIntegrationTests-Prefix.pch
+++ b/VENCoreIntegrationTests/VENCoreIntegrationTests-Prefix.pch
@@ -16,3 +16,4 @@
 
 #import "VENTestUtilities.h"
 
+#define VENFail() expect(YES).to.equal(NO)

--- a/VENCoreIntegrationTests/VENUserIntegrationSpec.m
+++ b/VENCoreIntegrationTests/VENUserIntegrationSpec.m
@@ -20,7 +20,7 @@ describe(@"Fetching a user", ^{
             expect(user.externalId).to.equal(externalId);
             done();
         } failure:^(NSError *error) {
-            XCTFail();
+            VENFail();
             done();
         }];
     });

--- a/VENCoreUnitTests/Models/Transactions/VENCreateTransactionRequestSpec.m
+++ b/VENCoreUnitTests/Models/Transactions/VENCreateTransactionRequestSpec.m
@@ -89,7 +89,7 @@ describe(@"Sending Payments With Stubbed Responses", ^{
                 expect([sentTransactions count]).to.equal(1);
                 done();
             } failure:^(NSArray *sentTransactions, VENHTTPResponse *response, NSError *error) {
-                XCTFail();
+                VENFail();
                 done();
             }];
         });
@@ -107,7 +107,7 @@ describe(@"Sending Payments With Stubbed Responses", ^{
                                                         failure:OCMOCK_ANY];
 
             [transactionService sendWithSuccess:^(NSArray *sentTransactions, VENHTTPResponse *response) {
-                XCTFail();
+                VENFail();
                 done();
             } failure:^(NSArray *sentTransactions, VENHTTPResponse *response, NSError *error) {
                 expect([sentTransactions count]).to.equal(0);
@@ -146,7 +146,7 @@ describe(@"Sending Payments With Stubbed Responses", ^{
                 expect([sentTransactions count]).to.equal(2);
                 done();
             } failure:^(NSArray *sentTransactions, VENHTTPResponse *response, NSError *error) {
-                XCTFail();
+                VENFail();
                 done();
             }];
         });
@@ -175,7 +175,7 @@ describe(@"Sending Payments With Stubbed Responses", ^{
                                                         failure:OCMOCK_ANY];
 
             [transactionService sendWithSuccess:^(NSArray *sentTransactions, VENHTTPResponse *response) {
-                XCTFail();
+                VENFail();
                 done();
             } failure:^(NSArray *sentTransactions, VENHTTPResponse *response, NSError *error) {
                 // The failure block shouldn't be called
@@ -203,7 +203,7 @@ describe(@"Sending Payments With Stubbed Responses", ^{
                                                         failure:OCMOCK_ANY];
             
             [transactionService sendWithSuccess:^(NSArray *sentTransactions, VENHTTPResponse *response) {
-                XCTFail();
+                VENFail();
                 done();
             } failure:^(NSArray *sentTransactions, VENHTTPResponse *response, NSError *error) {
                 expect([sentTransactions count]).to.equal(0);

--- a/VENCoreUnitTests/Models/Users/VENUserSpec.m
+++ b/VENCoreUnitTests/Models/Users/VENUserSpec.m
@@ -213,7 +213,7 @@ describe(@"Fetching a User", ^{
             expect(user.externalId).to.equal(externalId);
             done();
         } failure:^(NSError *error) {
-            XCTFail();
+            VENFail();
             done();
         }];
 
@@ -228,7 +228,7 @@ describe(@"Fetching a User", ^{
         [VENTestUtilities stubNetworkGET:urlToStub withStatusCode:400 andResponseFilePath:@"fetchInvalidUser"];
         
         [VENUser fetchUserWithExternalId:externalId success:^(VENUser *user) {
-            XCTFail();
+            VENFail();
             done();
         } failure:^(NSError *error) {
             expect([error localizedDescription]).to.equal(@"Resource not found.");
@@ -239,7 +239,7 @@ describe(@"Fetching a User", ^{
     
     it(@"should call failure when not passed an external id", ^AsyncBlock{
         [VENUser fetchUserWithExternalId:nil success:^(VENUser *user) {
-            XCTFail();
+            VENFail();
             done();
         } failure:^(NSError *error) {
             expect(error).notTo.beNil();
@@ -249,7 +249,7 @@ describe(@"Fetching a User", ^{
     
     it(@"should call failure when passed an empty-string external id", ^AsyncBlock{
         [VENUser fetchUserWithExternalId:@"" success:^(VENUser *user) {
-            XCTFail();
+            VENFail();
             done();
         } failure:^(NSError *error) {
             expect(error).notTo.beNil();
@@ -273,7 +273,7 @@ describe(@"Fetching Friends", ^{
             done();
  
         } failure:^(NSError *error){
-            XCTFail();
+            VENFail();
             done();
 
         }];
@@ -296,7 +296,7 @@ describe(@"Fetching Friends", ^{
             }
             done();
         } failure:^(NSError *error) {
-            XCTFail();
+            VENFail();
             done();
         }];
     });
@@ -315,7 +315,7 @@ describe(@"Fetching Friends", ^{
             }
             done();
         } failure:^(NSError *error) {
-            XCTFail();
+            VENFail();
             done();
         }];
     });
@@ -327,7 +327,7 @@ describe(@"Fetching Friends", ^{
         [VENTestUtilities stubNetworkGET:urlToStub withStatusCode:400 andResponseFilePath:@"fetchInvalidFriends"];
         
         [VENUser fetchFriendsWithExternalId:externalId success:^(NSArray *friendsArray) {
-            XCTFail();
+            VENFail();
             done();
         } failure:^(NSError *error) {
             expect([error localizedDescription]).to.equal(@"Resource not found.");
@@ -337,7 +337,7 @@ describe(@"Fetching Friends", ^{
     
     it(@"should call failure when not passed an external id", ^AsyncBlock{
         [VENUser fetchFriendsWithExternalId:nil success:^(NSArray *friendsArray) {
-            XCTFail();
+            VENFail();
             done();
         } failure:^(NSError *error) {
             expect(error).notTo.beNil();
@@ -347,7 +347,7 @@ describe(@"Fetching Friends", ^{
     
     it(@"should call failure when passed an empty-string external id", ^AsyncBlock{
         [VENUser fetchFriendsWithExternalId:@"" success:^(NSArray *friendsArray) {
-            XCTFail();
+            VENFail();
             done();
         } failure:^(NSError *error) {
             expect(error).notTo.beNil();

--- a/VENCoreUnitTests/Networking/VENHTTPSpec.m
+++ b/VENCoreUnitTests/Networking/VENHTTPSpec.m
@@ -108,7 +108,7 @@ describe(@"performing a request", ^{
                 expect(httpRequest.URL.scheme).to.equal(@"ven-http-test");
                 done();
             } failure:^(VENHTTPResponse *response, NSError *error) {
-                XCTFail();
+                VENFail();
             }];
         });
 
@@ -119,7 +119,7 @@ describe(@"performing a request", ^{
 
                 done();
             } failure:^(VENHTTPResponse *response, NSError *error) {
-                XCTFail();
+                VENFail();
             }];
         });
 
@@ -130,7 +130,7 @@ describe(@"performing a request", ^{
                 expect(httpRequest.URL.path).to.equal(@"/base/path/200.json");
                 done();
             } failure:^(VENHTTPResponse *response, NSError *error) {
-                XCTFail();
+                VENFail();
             }];
         });
     });
@@ -144,7 +144,7 @@ describe(@"performing a request", ^{
                 expect(httpRequest.HTTPBody).to.beNil();
                 done();
             } failure:^(VENHTTPResponse *response, NSError *error) {
-                XCTFail();
+                VENFail();
             }];
         });
 
@@ -157,7 +157,7 @@ describe(@"performing a request", ^{
                 expect(httpRequest.HTTPBody).to.beNil();
                 done();
             } failure:^(VENHTTPResponse *response, NSError *error) {
-                XCTFail();
+                VENFail();
             }];
         });
 
@@ -170,7 +170,7 @@ describe(@"performing a request", ^{
                 expect(httpRequest.URL.query).to.beNil();
                 done();
             } failure:^(VENHTTPResponse *response, NSError *error) {
-                XCTFail();
+                VENFail();
             }];
         });
 
@@ -184,7 +184,7 @@ describe(@"performing a request", ^{
                 expect(httpRequest.URL.query).to.beNil();
                 done();
             } failure:^(VENHTTPResponse *response, NSError *error) {
-                XCTFail();
+                VENFail();
             }];
         });
 
@@ -197,7 +197,7 @@ describe(@"performing a request", ^{
                 expect(httpRequest.URL.query).to.beNil();
                 done();
             } failure:^(VENHTTPResponse *response, NSError *error) {
-                XCTFail();
+                VENFail();
             }];
         });
 
@@ -211,7 +211,7 @@ describe(@"performing a request", ^{
                 expect(httpRequest.URL.query).to.beNil();
                 done();
             } failure:^(VENHTTPResponse *response, NSError *error) {
-                XCTFail();
+                VENFail();
             }];
         });
 
@@ -225,7 +225,7 @@ describe(@"performing a request", ^{
                 expect(httpRequest.URL.query).to.equal(nil);
                 done();
             } failure:^(VENHTTPResponse *response, NSError *error) {
-                XCTFail();
+                VENFail();
             }];
         });
 
@@ -239,7 +239,7 @@ describe(@"performing a request", ^{
                 expect(httpRequest.HTTPBody).to.beNil();
                 done();
             } failure:^(VENHTTPResponse *response, NSError *error) {
-                XCTFail();
+                VENFail();
             }];
         });
     });
@@ -252,7 +252,7 @@ describe(@"performing a request", ^{
                 expect(requestHeaders[@"Accept"]).to.equal(@"application/json");
                 done();
             } failure:^(VENHTTPResponse *response, NSError *error) {
-                XCTFail();
+                VENFail();
             }];
         });
 
@@ -263,7 +263,7 @@ describe(@"performing a request", ^{
                 expect(requestHeaders[@"User-Agent"]).to.contain(@"iOS");
                 done();
             } failure:^(VENHTTPResponse *response, NSError *error) {
-                XCTFail();
+                VENFail();
             }];
         });
 
@@ -274,7 +274,7 @@ describe(@"performing a request", ^{
                 expect(requestHeaders[@"Accept-Language"]).to.equal(@"en-US");
                 done();
             } failure:^(VENHTTPResponse *response, NSError *error) {
-                XCTFail();
+                VENFail();
             }];
         });
     });
@@ -300,7 +300,7 @@ describe(@"performing a request", ^{
                     expect(httpRequest.URL.query).to.equal(encodedParameters);
                     done();
                 } failure:^(VENHTTPResponse *response, NSError *error) {
-                    XCTFail();
+                    VENFail();
                 }];
             });
         });
@@ -317,7 +317,7 @@ describe(@"performing a request", ^{
                     
                     done();
                 } failure:^(VENHTTPResponse *response, NSError *error) {
-                    XCTFail();
+                    VENFail();
                 }];
             });
         });

--- a/VENCoreUnitTests/VENCoreUnitTests-Prefix.pch
+++ b/VENCoreUnitTests/VENCoreUnitTests-Prefix.pch
@@ -17,3 +17,5 @@
 #import "VENTestUtilities.h"
 
 #import "EXPMatchers+Venmo.h"
+
+#define VENFail() expect(YES).to.equal(NO)


### PR DESCRIPTION
This updates VENCore to work well with Xcode 6 and Cocoapods 0.34.0+ so that tests build and run directly after a fresh clone and ```pod install```.

Changes:
1. Updates ```Podfile``` to inhibit pod warnings and adds Cocoapods Spec source
2. ```pod update``` Nocilla to v0.9.0 so it builds on Xcode 6
3. Create ```VENFail()``` to replace ```XCTFail()```, which no longer works when using Specta

- [x] @ayanonagon 
- [x] @eliperkins 