### PR TITLE
add external linkage

### DIFF
--- a/VENCore/Networking/VENHTTPResponse.h
+++ b/VENCore/Networking/VENHTTPResponse.h
@@ -7,9 +7,9 @@
 
 @class AFHTTPRequestOperation;
 
-NSString *const VENErrorDomainHTTPResponse;
+extern NSString *const VENErrorDomainHTTPResponse;
 
-NS_ENUM(NSInteger, VEErrorCodeHTTPResponse) {
+extern NS_ENUM(NSInteger, VEErrorCodeHTTPResponse) {
     VENErrorCodeHTTPResponseUnauthorizedRequest,
     VENErrorCodeHTTPResponseBadResponse,
     VENErrorCodeHTTPResponseInvalidObjectType

--- a/VENCore/VENCore.h
+++ b/VENCore/VENCore.h
@@ -12,9 +12,9 @@
 #import "VENUser.h"
 #import "VENUserPayloadKeys.h"
 
-NSString *const VENErrorDomainCore;
+extern NSString *const VENErrorDomainCore;
 
-NS_ENUM(NSInteger, VENCoreErrorCode) {
+extern NS_ENUM(NSInteger, VENCoreErrorCode) {
     VENCoreErrorCodeNoDefaultCore,
     VENCoreErrorCodeNoAccessToken
 };


### PR DESCRIPTION
Right now there's an issue when you #import the Venmo API in multiple files because a few variables need external linkage. An issue was listed on the ios-sdk repo, but is due to a problem in core; see: https://github.com/venmo/venmo-ios-sdk/issues/78