### PR TITLE
Bugfix/support no common blocks

### DIFF
--- a/VENCore/Networking/VENHTTPResponse.h
+++ b/VENCore/Networking/VENHTTPResponse.h
@@ -7,7 +7,7 @@
 
 @class AFHTTPRequestOperation;
 
-NSString *const VENErrorDomainHTTPResponse;
+extern NSString *const VENErrorDomainHTTPResponse;
 
 NS_ENUM(NSInteger, VEErrorCodeHTTPResponse) {
     VENErrorCodeHTTPResponseUnauthorizedRequest,

--- a/VENCore/Networking/VENHTTPResponse.h
+++ b/VENCore/Networking/VENHTTPResponse.h
@@ -9,7 +9,7 @@
 
 extern NSString *const VENErrorDomainHTTPResponse;
 
-NS_ENUM(NSInteger, VEErrorCodeHTTPResponse) {
+typedef NS_ENUM(NSInteger, VEErrorCodeHTTPResponse) {
     VENErrorCodeHTTPResponseUnauthorizedRequest,
     VENErrorCodeHTTPResponseBadResponse,
     VENErrorCodeHTTPResponseInvalidObjectType

--- a/VENCore/VENCore.h
+++ b/VENCore/VENCore.h
@@ -14,7 +14,7 @@
 
 extern NSString *const VENErrorDomainCore;
 
-NS_ENUM(NSInteger, VENCoreErrorCode) {
+typedef NS_ENUM(NSInteger, VENCoreErrorCode) {
     VENCoreErrorCodeNoDefaultCore,
     VENCoreErrorCodeNoAccessToken
 };

--- a/VENCore/VENCore.h
+++ b/VENCore/VENCore.h
@@ -12,7 +12,7 @@
 #import "VENUser.h"
 #import "VENUserPayloadKeys.h"
 
-NSString *const VENErrorDomainCore;
+extern NSString *const VENErrorDomainCore;
 
 NS_ENUM(NSInteger, VENCoreErrorCode) {
     VENCoreErrorCodeNoDefaultCore,


### PR DESCRIPTION
Xcode 6.3.x now defaults the `GCC_NO_COMMON_BLOCKS` setting to `YES`. Without these fixes the linker will error out when compiling VENCore.