### PR TITLE
Version 3.1.3

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,6 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
-platform :ios, '6.0'
 inhibit_all_warnings!
 
 target 'VENCore', :exclusive => true do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - CMDQueryStringSerialization (0.3.2):
+  - CMDQueryStringSerialization (0.4.0):
     - ISO8601
   - Expecta (0.3.0)
   - ISO8601 (0.3.0)
@@ -9,7 +9,7 @@ PODS:
   - Specta (0.2.1)
 
 DEPENDENCIES:
-  - CMDQueryStringSerialization (~> 0.3)
+  - CMDQueryStringSerialization (~> 0.4)
   - Expecta
   - Nocilla
   - OCHamcrest
@@ -17,7 +17,7 @@ DEPENDENCIES:
   - Specta
 
 SPEC CHECKSUMS:
-  CMDQueryStringSerialization: 03c5d9847a4eaa2b3e4e439ce1ae24f914cc7fe1
+  CMDQueryStringSerialization: 71bb5c0014147c55089964df23fd6e44316bd6f5
   Expecta: 917bda2935b63ca7175741b8cf1b26796db6205f
   ISO8601: 8d8a22d5edf0554a1cf75bac028c76c1dc0ffaef
   Nocilla: d7d96e8a11e363f0d7c976d48b320c43d61fb471

--- a/VENCore.podspec
+++ b/VENCore.podspec
@@ -1,14 +1,14 @@
 Pod::Spec.new do |s|
   s.name         = 'VENCore'
-  s.version      = '3.1.2'
+  s.version      = '3.1.3'
   s.summary      = 'Core Venmo client library'
   s.description  = 'Core iOS client library for the Venmo api'
   s.homepage     = 'https://github.com/venmo/VENCore'
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { 'Venmo' => 'ios@venmo.com' }
-  s.platform     = :ios, '6.0'
+  s.platform     = :ios, '7.1'
   s.source       = { :git => 'https://github.com/venmo/VENCore.git',
                      :tag => "v#{s.version}" }
   s.source_files = 'VENCore/**/*.{h,m}'
-  s.dependency 'CMDQueryStringSerialization', '~> 0.3'
+  s.dependency 'CMDQueryStringSerialization', '~> 0.4'
 end


### PR DESCRIPTION
Changes:

* Bump CMDQueryStringSerialization to ~> 0.4
* Change deployment target to 7.1 since that's what we support in the Venmo app. CMDQueryStringSerialization requires >= 7.0. I think this is fine since even Facebook's app requires at least 7.

Code review:

- [x] @eliperkins 
- [x] @hyperspacemark  