### PR TITLE
Externalize the source of device-id

### DIFF
--- a/VENCore.podspec
+++ b/VENCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'VENCore'
-  s.version      = '3.1.4'
+  s.version      = '3.1.5'
   s.summary      = 'Core Venmo client library'
   s.description  = 'Core iOS client library for the Venmo api'
   s.homepage     = 'https://github.com/venmo/VENCore'

--- a/VENCore/Categories/UIDevice+VENCore.h
+++ b/VENCore/Categories/UIDevice+VENCore.h
@@ -4,6 +4,4 @@
 
 - (NSString *)VEN_platformString;
 
-- (NSString *)VEN_deviceIDString;
-
 @end

--- a/VENCore/Categories/UIDevice+VENCore.m
+++ b/VENCore/Categories/UIDevice+VENCore.m
@@ -16,18 +16,4 @@ NSString *const VENUserDefaultsKeyDeviceID = @"VenmoDeviceID";
     return platform;
 }
 
-
-- (NSString *)VEN_deviceIDString {
-    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-    NSString *uniqueIdentifier = [userDefaults stringForKey:VENUserDefaultsKeyDeviceID];
-    if (!uniqueIdentifier) {
-        CFUUIDRef uuid = CFUUIDCreate(kCFAllocatorDefault);
-        uniqueIdentifier = CFBridgingRelease(CFUUIDCreateString(kCFAllocatorDefault, uuid));
-        CFRelease(uuid);
-        [userDefaults setObject:uniqueIdentifier forKey:VENUserDefaultsKeyDeviceID];
-        [userDefaults synchronize];
-    }
-    return uniqueIdentifier;
-}
-
 @end

--- a/VENCore/Networking/VENHTTP.h
+++ b/VENCore/Networking/VENHTTP.h
@@ -9,7 +9,7 @@ extern NSString *const VENAPIPathUsers;
 
 @property (nonatomic, strong, readonly) NSURL *baseURL;
 
-- (instancetype)initWithBaseURL:(NSURL *)baseURL;
+- (instancetype)initWithBaseURL:(NSURL *)baseURL deviceID:(NSString *)deviceID;
 
 - (void)setProtocolClasses:(NSArray *)protocolClasses;
 

--- a/VENCore/Networking/VENHTTP.m
+++ b/VENCore/Networking/VENHTTP.m
@@ -14,6 +14,7 @@ NSString *const VENAPIPathUsers     = @"users";
 @interface VENHTTP ()<NSURLSessionDelegate>
 
 @property (strong, nonatomic) NSString *accessToken;
+@property (strong, nonatomic) NSString *deviceID;
 @property (nonatomic, strong) NSURLSession *session;
 @property (nonatomic, strong, readwrite) NSURL *baseURL;
 
@@ -21,11 +22,12 @@ NSString *const VENAPIPathUsers     = @"users";
 
 @implementation VENHTTP
 
-- (instancetype)initWithBaseURL:(NSURL *)baseURL
+- (instancetype)initWithBaseURL:(NSURL *)baseURL deviceID:(NSString *)deviceID
 {
     self = [self init];
     if (self) {
         self.baseURL = baseURL;
+        self.deviceID = deviceID;
         [self initializeSessionWithHeaders:self.defaultHeaders];
     }
     return self;
@@ -249,7 +251,10 @@ NSString *const VENAPIPathUsers     = @"users";
     [defaultHeaders addEntriesFromDictionary:@{@"User-Agent" : [self userAgentString],
                                                @"Accept": [self acceptString],
                                                @"Accept-Language": [self acceptLanguageString],
-                                               @"Device-ID" : [[UIDevice currentDevice] VEN_deviceIDString]}];
+                                               }];
+    if ([self deviceID]) {
+        defaultHeaders[@"device-id"] = [self deviceID];
+    }
     return defaultHeaders;
 }
 

--- a/VENCore/VENCore.h
+++ b/VENCore/VENCore.h
@@ -24,6 +24,9 @@ typedef NS_ENUM(NSInteger, VENCoreErrorCode) {
 
 @interface VENCore : NSObject
 
+- (instancetype)initWithDeviceID:(NSString *)deviceID;
+- (instancetype)initWithBaseURL:(NSURL *)baseURL deviceID:(NSString *)deviceID  NS_DESIGNATED_INITIALIZER;
+
 @property (strong, nonatomic) VENHTTP *httpClient;
 @property (strong, nonatomic) NSString *accessToken;
 

--- a/VENCore/VENCore.m
+++ b/VENCore/VENCore.m
@@ -10,14 +10,14 @@ static NSString *const VENAPIBaseURL = @"https://api.venmo.com/v1";
 
 #pragma mark - Private
 
-- (instancetype)init {
-    return [self initWithBaseURL:[NSURL URLWithString:VENAPIBaseURL]];
+- (instancetype)initWithDeviceID:(NSString *)deviceID {
+    return [self initWithBaseURL:VENAPIBaseURL deviceID:deviceID];
 }
 
-- (instancetype)initWithBaseURL:(NSURL *)baseURL {
+- (instancetype)initWithBaseURL:(NSURL *)baseURL deviceID:(NSString *)deviceID {
     self = [super init];
     if (self) {
-        self.httpClient = [[VENHTTP alloc] initWithBaseURL:baseURL];
+        self.httpClient = [[VENHTTP alloc] initWithBaseURL:baseURL deviceID:deviceID];
     }
     return self;
 }


### PR DESCRIPTION
Require externally generated device-id from caller
Podspec update to 3.1.5
